### PR TITLE
Remove ga-extension, we do it different now

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -53,7 +53,6 @@ eggs =
     sphinxcontrib-robotframework [docs]
     plone.app.robotframework [speak]
     sphinx.themes.plone
-    sphinxcontrib-googleanalytics
 
 initialization =
     # This enables po -> mo -compilation


### PR DESCRIPTION
The way how we include google-analyticsis changed, so we do not need this extension anymore
