### PR TITLE
fetch README.rst and CHANGES.rst for externals, limit history, warnings

### DIFF
--- a/conf/conf.py
+++ b/conf/conf.py
@@ -21,6 +21,16 @@
 
 # -- General configuration ----------------------------------------------------
 
+# 'monkey patch' sphinx to omit 'nonlocal image URI found' warnings
+import sphinx.environment
+from docutils.utils import get_source_line
+
+def _warn_node(self, msg, node):
+    if not msg.startswith('nonlocal image URI found:'):
+        self._warnfunc(msg, '%s:%s' % get_source_line(node))
+
+sphinx.environment.BuildEnvironment.warn_node = _warn_node
+
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [

--- a/externals.txt
+++ b/externals.txt
@@ -11,4 +11,5 @@ https://github.com/plone/plone.app.theming.git,source/documentation/external/plo
 https://github.com/plone/plone.app.testing.git,source/documentation/external/plone.app.testing
 https://github.com/collective/collective.transmogrifier.git,source/documentation/external/collective.transmogrifier
 https://github.com/plone/plone.app.caching.git,source/documentation/external/plone.app.caching
-https://github.com/plone/ansible-playbook,source/documentation/external/ansible-playbook
+https://github.com/plone/ansible-playbook.git,source/documentation/external/ansible-playbook
+https://github.com/plone/bobtemplates.plone.git,source/documentation/develop/addons/bobtemplates.plone

--- a/get_external_doc.sh
+++ b/get_external_doc.sh
@@ -7,10 +7,12 @@ do
         git pull
         cd -
     else
-        git clone $source $path
+        git clone --depth 1 $source $path
         cd $path
         git config core.sparsecheckout true
         echo docs/ > .git/info/sparse-checkout
+        echo README.rst >> .git/info/sparse-checkout
+        echo CHANGES.rst >> .git/info/sparse-checkout
         git read-tree -m -u HEAD
         cd -
     fi


### PR DESCRIPTION
This will fetch README.rst and CHANGES.rst. 

Also added --depth 1 to the pull; we're not interested in full git history of fetched external projects.

And suppressing the annoying "nonlocal URI image" warnings.