### PR TITLE
Better spellcheck

### DIFF
--- a/conf/conf.py
+++ b/conf/conf.py
@@ -53,6 +53,7 @@ dash_icon_file = 'source/documentation/_static/logo.png'
 
 # This is our wordlist with know words, like Github or Plone ...
 spelling_word_list_filename= 'spelling_wordlist.txt'
+spelling_ignore_pypi_package_names=True
 
 # Enable Robot Framework tests during Sphinx compilation:
 sphinxcontrib_robotframework_enabled = True  # 'True' is the default


### PR DESCRIPTION
This enhances spell-check:

Boolean controlling whether words that look like package names from PyPI are treated as spelled properly. When True, the current list of package names is downloaded at the start of the build and used to extend the list of known words in the dictionary. 

For more info: https://sphinxcontrib-spelling.readthedocs.org/en/latest/customize.html 
