### PR TITLE
Improve linkcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ APPLY_PROFILES = plone.app.contenttypes:plone-content
 ROBOTSERVER_FIXTURE = plone.app.robotframework.PLONE_ROBOT_TESTING
 ROBOTSERVER_OPTS = -v
 
-.PHONY: help clean html serve robot babel dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest pull spellcheck test dash
+.PHONY: help fast-link-check clean html serve robot babel dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest pull spellcheck test dash
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -48,6 +48,7 @@ help:
 	@echo "  test         to run linkcheck and spellcheck"
 	@echo "  changes      to get an overview what changed"
 	@echo "	 dash	      to create a docset"
+	@echo "  fast-link-check to check links without robot-framework"
 
 pull:
 	-bin/develop update $(PKGNAME)
@@ -154,6 +155,12 @@ linkcheck:
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in build/linkcheck/output.txt."
+
+fast-link-check:
+	$(SPHINXBUILD) -b linkcheck -D sphinxcontrib_robotframework_enabled=0 -j 4 $(ALLSPHINXOPTS) build/linkcheck
+	@echo
+	@echo "Link check complete; look for any errors in the above output " \
+	    	"or in build/linkcheck/output.txt."
 
 doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) build/doctest

--- a/conf/conf.py
+++ b/conf/conf.py
@@ -66,7 +66,8 @@ sphinxcontrib_robotframework_variables = {
 
 # Options for the linkcheck builder
 # Ignore localhost
-linkcheck_ignore = [r'http://localhost:\d+/']
+linkcheck_ignore = [r'http://localhost:\d+/',r'http://localhost:8080', r'http://127.0.0.1:8080', r'http://127.0.0.1' ]
+linkcheck_anchors = False
 
 
 # See http://sphinx-doc.org/ext/todo.html#confval-todo_include_todos


### PR DESCRIPTION
Changes:
- add settings to conf.py to ignore more 'local' options, like localhost, 127.0.0.1
- add new make target -> fast-link-check to check links with more cores and without robot-framework

results:
- faster link-check [handy for ci intregation]
- already less 'false positive' during link-check runs
