### PR TITLE
Phantom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ pip.log
 sphinx-build.log
 sphinx-latex.log
 sphinx-debug.log
+ghostdriver.log

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -35,8 +35,8 @@ sphinx-intl = git https://github.com/collective/sphinx-intl.git
 
 [versions]
 # use the same as the Plone release
-zc.buildout = 2.4.0
-setuptools = 18.0.1
+zc.buildout = 2.4.3
+setuptools = 18.3.1
 
 Sphinx = 1.3.1
 six = 1.9.0
@@ -44,6 +44,14 @@ Pygments = 2.0.2
 
 # robot-support requires the newest versions:
 docutils = 0.12
+
+plone.app.robotframework = 0.9.12
+robotframework = 2.9.1
+robotframework-selenium2library = 1.7.4
+robotframework-selenium2screenshots = 0.6.0
+robotsuite = 1.7.0
+selenium = 2.47.3
+sphinxcontrib-robotframework = 0.5.1
 
 [sphinx-build]
 recipe = zc.recipe.egg

--- a/conf/conf.py
+++ b/conf/conf.py
@@ -61,6 +61,7 @@ sphinxcontrib_robotframework_quiet = True  # 'False' is the default
 
 # Configure Robot Frameowrk tests to use Firefox
 sphinxcontrib_robotframework_variables = {
+#    "BROWSER": "phantomjs"  
     "BROWSER": "Firefox"  # 'Firefox' is the default
 }
 
@@ -174,11 +175,11 @@ html_theme_path = sphinx.themes.plone.get_html_theme_path()
 html_theme_options = {
 #	"rightsidebar": "false",
     'doc_languages' : [
-#        {'lang_code':'en','lang_name':'English'},
+        {'lang_code':'en','lang_name':'English'},
 #        {'lang_code':'de','lang_name':'German'},
 #        {'lang_code':'it','lang_name':'Italian'},
         ],
-    'doc_language'  : 'en',
+#    'doc_language'  : 'en',
     'trademark_name' : 'Plone',
     'googleanalytics_id': 'UA-1907133-6',
     'googleanalytics_domain': 'plone.org',
@@ -186,7 +187,7 @@ html_theme_options = {
     'external_topbar': True,
     'version_switcher': True,
     'always_show_version_switcher': True,
-    'always_show_language_switcher': False,
+    'always_show_language_switcher': True,
     'show_version_warning': True,
 }
 

--- a/docs/phantomjs.rst
+++ b/docs/phantomjs.rst
@@ -3,7 +3,7 @@ Using phantomjs
 
 Currently (status: 20151010) generating screenshots using `phantomjs <http://phantomjs.org/>`_ works, but is not standardly enabled.
 
-- for now, it is only tested against phantomjs 1.9.8, as there are build issues with 2.0 on Linux
+- for now, it is only tested against phantomjs 1.9.8, as there are build issues with 2.0 on Linux and OSX Yosemite
 - installing phantomjs is either platform-dependent, or uses an extra software stack (npm), so adds to the difficulty of getting papyrus to run
 
 So for now, it is only optional, and you will have to install phantomjs using your own OS or npm toolchain.

--- a/docs/phantomjs.rst
+++ b/docs/phantomjs.rst
@@ -1,0 +1,11 @@
+Using phantomjs
+===============
+
+Currently (status: 20151010) generating screenshots using `phantomjs <http://phantomjs.org/>`_ works, but is not standardly enabled.
+
+- for now, it is only tested against phantomjs 1.9.8, as there are build issues with 2.0 on Linux
+- installing phantomjs is either platform-dependent, or uses an extra software stack (npm), so adds to the difficulty of getting papyrus to run
+
+So for now, it is only optional, and you will have to install phantomjs using your own OS or npm toolchain.
+
+The default remains to use Firefox.


### PR DESCRIPTION
preparation to run screenshots with phantomjs ( only tested against phantomjs 1.9.8 and phantomjs has platform-dependent installation procedures. So not switching to it by default, but if you have phantomjs in your path you can switch)
