### PR TITLE
change how screenshots are generated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ sphinx-build.log
 sphinx-latex.log
 sphinx-debug.log
 ghostdriver.log
+log.html
+output.html
+report.html
+output.xml

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ ROBOTSERVER_OPTS = -v
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html      to make standalone HTML files without screenshots"
-	@echo "  screenshots	to generate the screenshots using robotframework"
+	@echo "  screenshot  	to generate the screenshots using robotframework"
 	@echo "  screenshots-phantomjs	to generate the screenshots using robotframework and the phantomjs browser, which needs to be available on your path"
-	@echo "	 full		to create a full, fresh build including screenshots"
-	@echo "  pullall	to refresh and update all external repositories"
+	@echo "	 full       to create a full, fresh build including screenshots"
+	@echo "  pullall    to refresh and update all external repositories"
 	@echo "  dirhtml   to make HTML files named index.html in directories"
 	@echo "  pickle    to make pickle files"
 	@echo "  gettext   to make i18n messages files"

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,11 @@ ROBOTSERVER_OPTS = -v
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  html      to make standalone HTML files"
+	@echo "  html      to make standalone HTML files without screenshots"
+	@echo "  screenshots	to generate the screenshots using robotframework"
+	@echo "  screenshots-phantomjs	to generate the screenshots using robotframework and the phantomjs browser, which needs to be available on your path"
+	@echo "	 full		to create a full, fresh build including screenshots"
+	@echo "  pullall	to refresh and update all external repositories"
 	@echo "  dirhtml   to make HTML files named index.html in directories"
 	@echo "  pickle    to make pickle files"
 	@echo "  gettext   to make i18n messages files"
@@ -62,6 +66,9 @@ externals:
 	@echo "use pullall instead id you want to update"
 	-bin/develop update *
 
+full: clean screenshots html
+
+
 clean:
 	-rm -rf build/*
 	-rm -rf source/$(PKGNAME)/_robot/*.png
@@ -69,9 +76,19 @@ clean:
 html: $(foreach lang,$(LANGS),html-$(lang))
 
 html-%: $(SPHINX_DEPENDENCIES)
-	LANGUAGE=$* $(SPHINXBUILD) -b html -w log/sphinx-build.log -D language=$* $(ALLSPHINXOPTS) build/html/$*
+	LANGUAGE=$* $(SPHINXBUILD) -b html -w log/sphinx-build.log -D language=$* -D sphinxcontrib_robotframework_enabled=0 $(ALLSPHINXOPTS) build/html/$*
 	@echo
 	@echo "Build finished. The HTML pages are in build/html."
+
+screenshots:
+	bin/pybot  --exclude wip-* --listener plone.app.robotframework.server.LazyStop source
+	@echo
+	@echo "Screenshot generation finished"
+
+screenshots-phantomjs:
+	bin/pybot  --variable BROWSER:phantomjs --exclude wip-* --listener plone.app.robotframework.server.LazyStop source
+	@echo
+	@echo "Screenshot generation finished"
 
 gettext:
 	$(SPHINXBUILD) -b gettext -c conf -D copyright="The Plone Foundation" source/$(PKGNAME) source/$(PKGNAME)/_locales

--- a/README.rst
+++ b/README.rst
@@ -67,12 +67,23 @@ Quick start
 	$ python bootstrap-buildout.py --setuptools-version=18.3.1 --version=2.4.3
 	$ bin/buildout
 
-2. Build docs [html version]
+2. Build docs [html version, no screenshots]
 
    .. code:: bash
 
       $ make html
 
+To generate just screenshots, do
+
+   .. code:: bash
+
+      $ make screenshots
+
+To generate the full documentation, do
+
+   .. code:: bash
+
+      $ make full
 
 Contribute
 ----------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -46,7 +46,7 @@ Pygments = 2.0.2
 # robot-support requires the newest versions:
 docutils = 0.12
 
-plone.app.robotframework = 0.9.12
+plone.app.robotframework = 0.9.14
 robotframework = 2.9.1
 robotframework-selenium2library = 1.7.4
 robotframework-selenium2screenshots = 0.6.0

--- a/conf/conf.py
+++ b/conf/conf.py
@@ -61,10 +61,9 @@ sphinxcontrib_robotframework_quiet = True  # 'False' is the default
 
 # Configure Robot Frameowrk tests to use Firefox
 sphinxcontrib_robotframework_variables = {
-#    "BROWSER": "phantomjs"  
+#    "BROWSER": "phantomjs"
     "BROWSER": "Firefox"  # 'Firefox' is the default
 }
-
 # Options for the linkcheck builder
 # Ignore localhost
 linkcheck_ignore = [r'http://localhost:\d+/',r'http://localhost:8080', r'http://127.0.0.1:8080', r'http://127.0.0.1' ]

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -39,14 +39,27 @@ Quick start
 	$ python bootstrap-buildout.py --setuptools-version=18.3.1 --version=2.4.3
 	$ bin/buildout
 
-2. Build docs [html version]
+2. Build docs [html version, no screenshots]
 
-.. code:: bash
+   .. code:: bash
 
       $ make html
 
+To generate just screenshots, do
+
+   .. code:: bash
+
+      $ make screenshots
+
+To generate the full documentation, do
+
+   .. code:: bash
+
+      $ make full
+
+(this is equivalent to "make clean && make screenshots && make html")
 
 Note that this will also generate robotscreenshots, so you will see Firefox opening multiple times.
 
-Re-running "make html" will only create robotscreenshots that are new or changed, so the whole process is quicker.
-When you are not changing robotscreenshots, you can also run "make debug" which will be significantly faster on multi-core machines.
+
+When you are not changing robotscreenshots, you can also run "make debug" which will be faster on multi-core machines.

--- a/docs/phantomjs.rst
+++ b/docs/phantomjs.rst
@@ -1,11 +1,15 @@
 Using phantomjs
 ===============
 
-Currently (status: 20151010) generating screenshots using `phantomjs <http://phantomjs.org/>`_ works, but is not standardly enabled.
+Currently (status: 2015-10-17) generating screenshots using `phantomjs <http://phantomjs.org/>`_ works, but is not standardly enabled.
 
 - for now, it is only tested against phantomjs 1.9.8, as there are build issues with 2.0 on Linux and OSX Yosemite
 - installing phantomjs is either platform-dependent, or uses an extra software stack (npm), so adds to the difficulty of getting papyrus to run
 
 So for now, it is only optional, and you will have to install phantomjs using your own OS or npm toolchain.
+Run "make screenshots-phantomjs" to use phantomjs.
+
+*NOTE: not all tests/screenshots are fully updated for phantomjs yet.
+Since execution speed is much faster, we will need to add more conditions like "Wait Until Page Contains  xxx" to ensure stable tests. This affects mainly the 'collaboration' section at the moment (2015-10-17)*
 
 The default remains to use Firefox.

--- a/docs/robots.rst
+++ b/docs/robots.rst
@@ -16,7 +16,7 @@ Look at an example in `Change the Logo <https://raw.githubusercontent.com/plone/
 
 When working on making robot-screenshots, your development will be much faster if you use the following order:
 
-- run "make html" once to get everything going
+- run "make screenshots" once to get everything going
 - run "make serve"
 - open another terminal, run "make robot" from there. It will only create the new or edited screenshots
 - wash, rinse, repeat
@@ -70,7 +70,7 @@ We support two different build modes:
 * standalone builds
 * robot-server -dependent builds.
 
-*Standalone*-build is executed with familiar ``make html`` and with it
+*Standalone*-build is executed with familiar ``make full`` and with it
 each document can setup the required Plone sandboxes during the Sphinx
 compilation process by itself. It's good for building the complete docs,
 but is slow when used for writing the robot code for screenshots
@@ -291,6 +291,10 @@ Advanced topics
    with environment variables when starting *robot-server*. See Makefile for
    examples.
 
+9. How to exclude tests that are not working:
+
+   Tag any test with ``wip-*``, so for instance "wip-needs_review" or "wip-only_works_on_windows"
+   See http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#tagging-test-cases
 
 Multilingual demo
 -----------------

--- a/docutils.conf
+++ b/docutils.conf
@@ -1,0 +1,2 @@
+[general]
+report_level = 5


### PR DESCRIPTION
screenshots are generated by calling pybot, so they can fail hard on CI.

to generate a full set of docs including screenshots now do

make full (equivalent to "make clean && make screenshots && make html")

also adds support for generating screenshots with phantomjs (still needs refinement and more testing)
