### PR TITLE
buildout.coredev: use depth=1.

### DIFF
--- a/checkouts-documentation.cfg
+++ b/checkouts-documentation.cfg
@@ -43,10 +43,7 @@ zope = https://github.com/zopefoundation
 
 #documentation is special, we want full history and push URL
 documentation               = git ${remotes-https:plone}/documentation.git egg=false branch=5.0
-
-#bug in mr.developer: you can't specify a non-default branch AND use depth=1. Bummer!
-buildout.coredev            = git ${remotes-https:plone}/buildout.coredev.git egg=false branch=5.0
-
+buildout.coredev            = git ${remotes-https:plone}/buildout.coredev.git egg=false depth=1 branch=5.0
 ansible-playbook            = git ${remotes-https:plone}/ansible-playbook.git egg=false depth=1 branch=master
 bobtemplates.plone          = git ${remotes-https:plone}/bobtemplates.plone.git egg=false depth=1 branch=master
 plone.api                   = git ${remotes-https:plone}/plone.api.git egg=false depth=1 branch=master
@@ -117,4 +114,3 @@ update-command = ${:command}
 
 [versions]
 mr.developer = >= 1.33
-


### PR DESCRIPTION
Works fine with non-master branches, at least in mr.developer 1.33+ on my Mac.

After removing checkout/buildout.coredev and running buildout again, I have 620 KB in that directory Instead of 117 MB.
