### PR TITLE
Include all *.rst files for external repositories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 $NEXT_RELEASE
 -------------
 
+- Include all *.rst files for external sparse-checkout turned repositories. [thet]
 - Add plone.testing, which is referenced by plone/documentation. [thet]
 - update makefile to have "make robot" provide a full environment with demo content (polyester)
 - extended exclude_patterns to not process CHANGES.rst and LICENSE.rst files for contributed externals (polyester)

--- a/assemble-docs.tpl.genshi
+++ b/assemble-docs.tpl.genshi
@@ -15,8 +15,7 @@ if [ ! -f "${parts['buildout']['sources-dir']}/${package}/.git/info/sparse-check
     cd ${parts['buildout']['sources-dir']}/${package}
     git config core.sparsecheckout true
     echo ${relpath}/ > .git/info/sparse-checkout
-    echo README.rst >> .git/info/sparse-checkout
-    echo CHANGES.rst >> .git/info/sparse-checkout
+    echo "*.rst" >> .git/info/sparse-checkout
     git read-tree -m -u HEAD
     cd - >/dev/null
 fi


### PR DESCRIPTION
I want to include plone.memoize docs, which have a lot of doctests in plone.memoize/plone/memoize directory. When turning into a sparce-checkout repo, these doctests aren't picked up.
This change just includes all *.rst files recursively.
