### PR TITLE
Part 1 of fix for https://github.com/plone/documentation/issues/546

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ screenshots-phantomjs:
 	@echo "Screenshot generation finished"
 
 gettext:
-	$(SPHINXBUILD) -b gettext -c conf -D copyright="The Plone Foundation" source/$(PKGNAME) source/$(PKGNAME)/_locales
+	$(SPHINXBUILD) -b gettext -c conf -D copyright="The Plone Foundation" -D sphinxcontrib_robotframework_enabled=0 source/$(PKGNAME) source/$(PKGNAME)/_locales
 	@echo
 	@echo "Build finished. The HTML pages are in build/gettext."
 

--- a/conf/conf.py
+++ b/conf/conf.py
@@ -115,6 +115,7 @@ exclude_patterns = ['README.rst', '_*.rst',
                     'external/plone.api/docs/CHANGES.rst',
                     'develop/plone-coredev/es/*',
                     'develop/plone-coredev/pt_BR',
+                    '_locales/*',
                     'external/Products.TinyMCE/docs/source/contributors.rst',
                     '**/CHANGES.rst',
                     '**/LICENSE.rst',]


### PR DESCRIPTION
- ignore _locales for sphinx build
- disable robots for .po creation

If that is merged, we can move on and remove the _local directory for the docs repo, it is not needed and sphinx will create it itself
