### PR TITLE
No longer checkout and symlink bobtemplates.plone.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2016xxxx
 --------
 
+- No longer checkout and symlink bobtemplates.plone, which is already included. [maurits]
 - Pull ansible docs from STABLE branch [smcmahon]
 - add option to use Chrome, update robotframework versions [polyester]
 

--- a/checkouts-documentation.cfg
+++ b/checkouts-documentation.cfg
@@ -13,7 +13,6 @@ always-checkout = false
 
 auto-checkout +=
     ansible-playbook
-    bobtemplates.plone
     buildout.coredev
     collective.transmogrifier
     diazo
@@ -46,7 +45,6 @@ zope = https://github.com/zopefoundation
 documentation               = git ${remotes-https:plone}/documentation.git egg=false branch=5.0
 buildout.coredev            = git ${remotes-https:plone}/buildout.coredev.git egg=false depth=1 branch=5.0
 ansible-playbook            = git ${remotes-https:plone}/ansible-playbook.git egg=false depth=1 branch=STABLE
-bobtemplates.plone          = git ${remotes-https:plone}/bobtemplates.plone.git egg=false depth=1 branch=master
 plone.api                   = git ${remotes-https:plone}/plone.api.git egg=false depth=1 branch=master
 collective.transmogrifier   = git ${remotes-https:collective}/collective.transmogrifier.git egg=false depth=1 branch=master
 
@@ -85,7 +83,6 @@ plone.testing += egg=false depth=1
 
 1-COMMAND                           = mkdir -p ${buildout:docs-dir}
 1-documentation                     = documentation
-2-bobtemplates.plone/docs           = documentation/develop/addons/bobtemplates.plone
 2-buildout.coredev/docs             = documentation/develop/coredev
 3-COMMAND                           = mkdir -p ${buildout:docs-dir}/documentation/external
 3-ansible-playbook/docs             = documentation/external/ansible-playbook


### PR DESCRIPTION
Those docs have been merged into the documentation repo.
The symlink was created in documentation/develop/addons/bobtemplates.plone
but this already existed, so you got a bobtemplates.plone/bobtemplates.plone symlink.
