### PR TITLE
Pin urllib3 to 1.17 to avoid Travis failure.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2016xxxx
 --------
 
+- pin urllib3 [mauritsvanrees]
 - Switch to pip install zc.buildout
 - Pull ansible docs from STABLE branch [smcmahon]
 - add option to use Chrome, update robotframework versions [polyester]

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -48,6 +48,11 @@ Pygments = 2.1.3
 # robot-support requires the newest versions:
 docutils = 0.12
 
+# latest urllib3 1.18 fails to install on Travis, due to
+# 'secure:python_version <= "2.7"' in its setup.py
+# 1.19 should be fine once it is released.
+urllib3 = 1.17
+
 plone.app.robotframework = 0.9.16
 robotframework = 3.0
 robotframework-selenium2library = 1.7.4


### PR DESCRIPTION
A newer setuptools might help, but the problem is fixed upstream in urllib3 already,
but not released yet.

See the error at https://travis-ci.org/plone/documentation/builds/170717996:

```
Getting distribution for 'urllib3'.
error: Setup script exited with error in urllib3 setup command: Invalid environment marker: python_version <= "2.7"
An error occurred when trying to install urllib3 1.18. Look above this message for any errors that were output by easy_install.
While:
  Installing sphinx-intl.
  Getting distribution for 'urllib3'.
Error: Couldn't install: urllib3 1.18
```
