### PR TITLE
Pin plone.app.robotframework = 1.0.2 [fixes #129]

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -53,7 +53,7 @@ docutils = 0.12
 # 1.19 should be fine once it is released.
 urllib3 = 1.17
 
-plone.app.robotframework = 0.9.16
+plone.app.robotframework = 1.0.2
 robotframework = 3.0
 robotframework-selenium2library = 1.7.4
 robotframework-selenium2screenshots = 0.7.0


### PR DESCRIPTION
Fixes #129 /cc @MrTango

There's an old hack lurking in plone.app.robotframework:

When we were planning scripted screenshots, we helped robotframework to include better built-in support for docutils. The result: Robot Framework (and its pybot-runner) can parse RST files and execute Robot Framework test cases from ``.. code:: robotframework`` block directives. This is all built-in, no **sphinxcontrib-robotframework** or **plone.app.robotframework** needed.

Yet, Sphinx and its extensions extend docutils with custom roles and directives. This is not a problem when robotframework is executed within Sphinx build, like **sphinxcontrib-robotframework** does, because all those extensions are registered. But may be a problem when Sphinx documentation is called with just **pybot**, because the documentation may contain Sphinx-specific directives and fails to parse with vanilla docutils.

To coup this difference, I introduced customized pybot-entrypoint into plone.app.robotframework (to be honest, we already had it there before, because in the early days robotframework was missing setuptools compatible entrypoint). There I inject a few dummy docutils directives and roles into pybot to make it parse most typical Sphinx documents. Unfortunately, there was an issue with dummy ``:ref:``-replacement. That should be now fixed.

I see that you'll avoid possible similar issues in the future, since you are probably moving screenshot scripts out of the RST files...