### PR TITLE
pin the version of buildout

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-zc.buildout
+zc.buildout==2.4.3


### PR DESCRIPTION
The buildout requirement in the requirement.txt creates conflict with the pinned version in the buildout.cfg. Pinning the version of the buildout in the requirement.txt might fix this problem