### PR TITLE
Removed version dropdown.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2017xxx
 -------
 
+- Removed version dropdown. [maurits]
 - Remove unused add-ons out of sphinx conf [svx]
 - More general cleanup [svx]
 - Remove dash builder, since we're not using it since a long time [svx]

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -37,8 +37,7 @@ sphinxcontrib-osexample = git https://github.com/svx/sphinxcontrib-osexample.git
 
 [versions]
 Sphinx = 1.6.2
-sphinxtheme.plone = 0.5.2
-#sphinxtheme.plone =
+sphinxtheme.plone = 0.5.6
 
 [sphinx-build]
 recipe = zc.recipe.egg

--- a/conf/conf.py
+++ b/conf/conf.py
@@ -90,14 +90,7 @@ trademark_name = "Plone"
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-#
-# The versions appearing in the version drop-down. We use 'newest first'
-# You should set the selected_version in the html_theme_options further in the file.
-version = [
-    '5',
-    '4',
-    '3',
-]
+version = '5'
 # The full version, including alpha/beta/rc tags.
 release = '5.1'
 
@@ -178,11 +171,10 @@ html_theme_options = {
     'googleanalytics_domain': 'plone.org',
     'googleanalytics_path': '/',
     'external_topbar': True,
-    'version_switcher': True,
-    'always_show_version_switcher': True,
+    'version_switcher': False,
+    'always_show_version_switcher': False,
     'always_show_language_switcher': True,
-    'show_version_warning': True,
-    'selected_version': '5',
+    'show_version_warning': False,
     'use_freshdesk': False,
     'use_gitter': True,
 }


### PR DESCRIPTION
As seen on the Ploneconf sprint, the version dropdown gives a traceback when running `make html`. It should be a string instead of a list. But we decided it should be removed entirely.

TODO: put a link to version 4 somewhere, but Paul volunteered for that part. ;-)