### PR TITLE
at least document the sorry state for ubuntu 2018

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ output.html
 report.html
 output.xml
 share/
+build/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+20181002
+--------
+
+- update instructions to work on Ubuntu 18.04
+
 20180401
 --------
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -33,6 +33,8 @@ sphinxcontrib-osexample = git https://github.com/svx/sphinxcontrib-osexample.git
 Sphinx = 1.7.2
 sphinxtheme.plone = 0.5.7
 Jinja2 = 2.10
+setuptools=39.1.0
+zc.buildout=2.11.4
 
 [sphinx-build]
 recipe = zc.recipe.egg

--- a/checkouts-documentation.cfg
+++ b/checkouts-documentation.cfg
@@ -1,7 +1,7 @@
 [buildout]
 
 extends =
-    https://raw.githubusercontent.com/plone/buildout.coredev/5.0/sources.cfg
+    https://raw.githubusercontent.com/plone/buildout.coredev/5.1/sources.cfg
 
 
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,7 +7,7 @@ Requirements
 
 Since Papyrus uses robot-framework for fully automated screenshots, the buildout will install Plone.
 Also, to generate PDF, you'll need latex, which is a large package.
-To install Papyrus with all features and possibilites on Ubuntu 14.04 you will need:
+To install Papyrus with all features and possibilites on Ubuntu 18.04 you will need:
 
 .. code-block:: bash
 
@@ -20,8 +20,8 @@ To install Papyrus with all features and possibilites on Ubuntu 14.04 you will n
     python-dev
     libjpeg-dev
     libxml2-dev
-    libxslt-dev
-    libz-dev
+    libxslt1-dev
+    zlib1g-dev
     firefox
     texlive-latex-extra
     texlive-latex-recommended
@@ -40,27 +40,18 @@ Quick Start
    pip install -r https://raw.githubusercontent.com/plone/buildout.coredev/5.1/requirements.txt
    bin/buildout
 
-2. Build docs [html version, no screenshots]
+2. Download the latest known good screenshots
 
    .. code:: bash
 
-      $ make html
+      $ cd source/documentation
+      $ git clone https://github.com/plone/documentation-roboshots.git
+      $ mv documentation/roboshots/* _robot/
 
-To generate just screenshots, do
-
-   .. code:: bash
-
-      $ make screenshots
 
 To generate the full documentation, do
 
    .. code:: bash
 
-      $ make full
+      $ make html
 
-(this is equivalent to "make clean && make screenshots && make html")
-
-Note that this will also generate robotscreenshots, so you will see Firefox opening multiple times.
-
-
-When you are not changing robotscreenshots, you can also run "make debug" which will be faster on multi-core machines.


### PR DESCRIPTION
while papyrus should be retired, at least document how it runs on Ubuntu 18.04, with updated library names and procedures.